### PR TITLE
Merge fix from upstream

### DIFF
--- a/lib/neon_circular_timer.dart
+++ b/lib/neon_circular_timer.dart
@@ -18,7 +18,7 @@ class NeonCircularTimer extends StatefulWidget {
   final Gradient? innerFillGradient;
 
   /// Filling Color for Countdown circle.
-  final Color? backgroudColor;
+  final Color? backgroundColor;
 
   /// Ring Color for Countdown Widget.
   final Color? neonColor;


### PR DESCRIPTION
Fix typo in `lib/neon_circular_timer.dart`: `backgoudColor` --> `backgroundColor`